### PR TITLE
parameter[:getter]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Add support for :getter parameter option to explicitly define custom param getter method and avoid rspec conflicts with `include` matcher and `status` method
+
 ### Changed
 
 - Remove commented code (https://github.com/rswag/rswag/pull/576)

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ end
 
 #### Nullable or Optional Response Headers ####
 
-You can include `nullable` or `required` to specify whether a response header must be present or may be null. When `nullable` is not included, the headers validation validates that the header response is non-null. When `required` is not included, the headers validation validates the the header response is passed. 
+You can include `nullable` or `required` to specify whether a response header must be present or may be null. When `nullable` is not included, the headers validation validates that the header response is non-null. When `required` is not included, the headers validation validates the the header response is passed.
 
 ```ruby
 # spec/integration/comments_spec.rb
@@ -983,3 +983,21 @@ docker run -d -p 80:8080 swaggerapi/swagger-editor
 ```
 This will run the swagger editor in the docker daemon and can be accessed
 at ```http://localhost```. From here, you can use the UI to load the generated swagger.json to validate the output.
+
+### Custom :getter option for paramater
+
+To avoid conflicts with rspec `included` matcher and other possible intersections like `status` method:
+
+```
+...
+parameter name: :status,
+          getter: :filter_status,
+          in: :query,
+          schema: {
+            type: :string,
+            enum: %w[one two three],
+          }, required: false
+
+let(:status) { nil } # will not be used in query string
+let(:filter_status) { 'one' } # `&status=one` will be provided in final query
+```

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -58,6 +58,9 @@ module Rswag
                 if is_hash && value[:parameters]
                   schema_param = value[:parameters]&.find { |p| (p[:in] == :body || p[:in] == :formData) && p[:schema] }
                   mime_list = value[:consumes] || doc[:consumes]
+
+                  value[:parameters].each {|p| p.delete(:getter) } # remove service field
+
                   if value && schema_param && mime_list
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
                     value[:requestBody][:required] = true if schema_param[:required]

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -31,15 +31,15 @@ module Rswag
         end
 
         context "'path' parameters" do
-          context 'when `name` parameter key is required, but not defined within example group' do
-            before do
-              metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
-              metadata[:operation][:parameters] = [
-                { name: 'blog_id', in: :path, type: :number },
-                { name: 'id', in: :path, type: :number }
-              ]
-            end
+          before do
+            metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
+            metadata[:operation][:parameters] = [
+              { name: 'blog_id', in: :path, type: :number },
+              { name: 'id', in: :path, type: :number }
+            ]
+          end
 
+          context 'when `name` parameter key is required, but not defined within example group' do
             it "explicitly warns user about missing parameter, instead of giving generic error" do
               expect { request[:path] }.not_to raise_error(/undefined method/)
               expect { request[:path] }.not_to raise_error(/is not available from within an example/)
@@ -49,17 +49,27 @@ module Rswag
 
           context 'when `name` is defined' do
             before do
-              metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
-              metadata[:operation][:parameters] = [
-                { name: 'blog_id', in: :path, type: :number },
-                { name: 'id', in: :path, type: :number }
-              ]
               allow(example).to receive(:blog_id).and_return(1)
               allow(example).to receive(:id).and_return(2)
             end
 
             it 'builds the path from example values' do
               expect(request[:path]).to eq('/blogs/1/comments/2')
+            end
+
+            context 'when `getter is defined`' do
+              before do
+                metadata[:operation][:parameters] = [
+                  { name: 'blog_id', in: :path, type: :number },
+                  { name: 'id', in: :path, type: :number, getter: :param_id }
+                ]
+
+                allow(example).to receive(:param_id).and_return(123)
+              end
+
+              it 'builds the path using getter method' do
+                expect(request[:path]).to eq('/blogs/1/comments/123')
+              end
             end
           end
         end
@@ -77,48 +87,66 @@ module Rswag
           it 'builds the query string from example values' do
             expect(request[:path]).to eq('/blogs?q1=foo&q2=bar')
           end
+
+          context 'when `getter is defined`' do
+            before do
+              metadata[:operation][:parameters] << {
+                name: 'status', in: :query, type: :string, getter: :q3_status
+              }
+
+              allow(example).to receive(:status).and_return(nil)
+              allow(example).to receive(:q3_status).and_return(123)
+            end
+
+            it 'builds the query string using getter ethod' do
+              expect(request[:path]).to eq('/blogs?q1=foo&q2=bar&status=123')
+            end
+          end
         end
 
         context "'query' parameters of type 'array'" do
           before do
             metadata[:operation][:parameters] = [
-              { name: 'things', in: :query, type: :array, collectionFormat: collection_format }
+              { name: 'things', in: :query, type: :array, collectionFormat: collection_format },
+              { name: 'nums', in: :query, type: :array, collectionFormat: collection_format, getter: :nums_param },
             ]
             allow(example).to receive(:things).and_return(['foo', 'bar'])
+            allow(example).to receive(:nums).and_return(nil)
+            allow(example).to receive(:nums_param).and_return([0, 1])
           end
 
           context 'collectionFormat = csv' do
             let(:collection_format) { :csv }
             it 'formats as comma separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo,bar')
+              expect(request[:path]).to eq('/blogs?things=foo,bar&nums=0,1')
             end
           end
 
           context 'collectionFormat = ssv' do
             let(:collection_format) { :ssv }
             it 'formats as space separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo bar')
+              expect(request[:path]).to eq('/blogs?things=foo bar&nums=0 1')
             end
           end
 
           context 'collectionFormat = tsv' do
             let(:collection_format) { :tsv }
             it 'formats as tab separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo\tbar')
+              expect(request[:path]).to eq('/blogs?things=foo\tbar&nums=0\t1')
             end
           end
 
           context 'collectionFormat = pipes' do
             let(:collection_format) { :pipes }
             it 'formats as pipe separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo|bar')
+              expect(request[:path]).to eq('/blogs?things=foo|bar&nums=0|1')
             end
           end
 
           context 'collectionFormat = multi' do
             let(:collection_format) { :multi }
             it 'formats as multiple parameter instances' do
-              expect(request[:path]).to eq('/blogs?things=foo&things=bar')
+              expect(request[:path]).to eq('/blogs?things=foo&things=bar&nums=0&nums=1')
             end
           end
         end
@@ -271,12 +299,16 @@ module Rswag
 
         context "'header' parameters" do
           before do
-            metadata[:operation][:parameters] = [{ name: 'Api-Key', in: :header, type: :string }]
+            metadata[:operation][:parameters] = [
+              { name: 'Api-Key', in: :header, type: :string },
+              { name: 'Token', getter: :token_param, in: :header, type: :string }
+            ]
             allow(example).to receive(:'Api-Key').and_return('foobar')
+            allow(example).to receive(:'token_param').and_return('my_token')
           end
 
           it 'adds names and example values to headers' do
-            expect(request[:headers]).to eq({ 'Api-Key' => 'foobar' })
+            expect(request[:headers]).to eq({ 'Api-Key' => 'foobar', 'Token' => 'my_token' })
           end
         end
 


### PR DESCRIPTION
## Problem
Adopted pull request https://github.com/rswag/rswag/pull/436
Fix known issue: conflict with rspec default matchers include https://github.com/rswag/rswag/issues/188 (and also with `status` method)

## Solution
Add support for :getter parameter option to explicitly define custom param getter method and avoid rspec conflicts with `include` matcher and `status` method

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
https://github.com/rswag/rswag/issues/188

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
